### PR TITLE
refact: road HillShade 계산과 업데이트 분리

### DIFF
--- a/src/main/java/geo/hs/controller/HillShadeController.java
+++ b/src/main/java/geo/hs/controller/HillShadeController.java
@@ -57,9 +57,10 @@ public class HillShadeController {
 		int time = req.getTime().charAt(0) == '0' ? req.getTime().charAt(1) - '0' : Integer.valueOf(req.getTime());
 		ArrayList<Hillshade> hs1DArr = hillShadeService.run(dsm2DArr, si.getArr().get(time));
 
-
-		// 계산된 HillShade값 DB에 갱신
-		roadService.updateRoadHillShade(hs1DArr);
+		// 일정 크기의 HillShade 리스트에 대한 road HillShade 값 계산
+		roadService.calcRoadHillShade(hs1DArr);
+		// 최종 계산된 road HillShade 값 DB에 갱신
+		roadService.updateRoadHillShade();
 	}
 	
 	@PostMapping("/test")

--- a/src/main/java/geo/hs/service/RoadService.java
+++ b/src/main/java/geo/hs/service/RoadService.java
@@ -15,10 +15,13 @@ public class RoadService {
     private final RoadRepository roadRepository;
     private final HashMap<Integer, Road> roadHashMap = new HashMap<>();
 
-    public void updateRoadHillShade(List<Hillshade> hillShades) {
+    public void calcRoadHillShade(List<Hillshade> hillShades) {
         for (Hillshade hillShade : hillShades) {
             roadRepository.findByGeom(roadHashMap, hillShade);
         }
+    }
+
+    public void updateRoadHillShade() {
         for (Road value : roadHashMap.values()) {
             roadRepository.updateHillShade(value);
         }


### PR DESCRIPTION
#19 pr에서 이슈가 생긴 HillShade 계산 중 heap overflow 문제가 Hillshade 정보를 한꺼번에 리스트로 받아서 생기는 문제라 생각했습니다.
그래서 Hillshade 정보를 조금씩 받는다는 가정하에 road의 HillShade의 계산과 업데이트 기능을 분리했습니다.

일정 크기로 수집된 Hillshade 정보를 road HillShade에 계산시키고 싶을 때 calcRoadHillShade 메소드에 Hillshade 리스트를 전달해주시면 됩니다.