### PR TITLE
Refact: hillshade 계산을 시도코드가 아닌 시군구 코드로 변경

### DIFF
--- a/src/main/java/geo/hs/controller/HillShadeController.java
+++ b/src/main/java/geo/hs/controller/HillShadeController.java
@@ -80,7 +80,6 @@ public class HillShadeController {
 		log.info("Dsm을 2D Arr로 변경하는데 걸리는 시간 = {} sec 입니다.", (endTime - startTime) / 1000);
 		log.info("DSMS ARR 크기 = {}", dsms.size());
 //		dsms = null;
-//		System.gc();
 		
 		// 태양고도각 크롤링
 		// crawler 호출

--- a/src/main/java/geo/hs/model/dsm/Dsm.java
+++ b/src/main/java/geo/hs/model/dsm/Dsm.java
@@ -18,10 +18,10 @@ public class Dsm  implements Comparable<Dsm>{
 	
 	@Override
 	public int compareTo(Dsm dsm) {
-		if (Double.valueOf(dsm.x) < Double.valueOf(x)) return 1;
-		else if (Double.valueOf(dsm.x) >= Double.valueOf(x)) {
-			if(Double.valueOf(dsm.y) < Double.valueOf(y)) return 1;
-			else if(Double.valueOf(dsm.y) > Double.valueOf(y)) return -1;
+		if (Double.parseDouble(dsm.x) < Double.parseDouble(x)) return 1;
+		else if (Double.parseDouble(dsm.x) >= Double.parseDouble(x)) {
+			if(Double.parseDouble(dsm.y) < Double.parseDouble(y)) return 1;
+			else if(Double.parseDouble(dsm.y) > Double.parseDouble(y)) return -1;
 			return 0;
 		}
 		else return 0;

--- a/src/main/java/geo/hs/repository/GetDsmRepository.java
+++ b/src/main/java/geo/hs/repository/GetDsmRepository.java
@@ -28,35 +28,7 @@ public class GetDsmRepository {
 						rs.getString("y"),
 						rs.getDouble("z"),
 						0),
-				cityId + "%"
+				cityId
 		);
 	}
-	
-	public List<Dsm> getAllDsm(){
-		/*List<Dsm> ret = new ArrayList<>();
-		for(int i=0; i<20000000; i+=1000000){ // 100만 단위로 끊어서 가지고 오고, List 병합, 각 지역별 최대 DSM 개수 구해서 조건문 변경하기
-			String query = "select * from DSM ORDER BY x asc, y asc OFFSET ? LIMIT 1000000";
-			List<Dsm> temp = this.jdbcTemplate.query(query,
-					(rs, rowNum) -> new Dsm(
-							rs.getString("x"),
-							rs.getString("y"),
-							rs.getDouble("z"),
-							0),
-					i
-			);
-			if(temp.isEmpty()) break; // 더 이상 가져오는 것이 없다면 break
-			ret.addAll(temp);
-		}
-		return ret;*/
-		// where 문의 city 부분은 db의 컬럼에 따라 변경
-		String query = "select * from dsm";
-		return this.jdbcTemplate.query(query,
-				(rs, rowNum) -> new Dsm(
-						rs.getString("x"),
-						rs.getString("y"),
-						rs.getDouble("z"),
-						0)
-		);
-	}
-	
 }

--- a/src/main/java/geo/hs/repository/RoadRepository.java
+++ b/src/main/java/geo/hs/repository/RoadRepository.java
@@ -22,7 +22,7 @@ public class RoadRepository {
     }
 
     public void findByGeom(HashMap<Integer, Road> roadHashMap, Hillshade hillShades) {
-        String sql = "SELECT id FROM road_centroid WHERE ST_Intersects(?, centroid)";
+        String sql = "SELECT id FROM road_split WHERE ST_Intersects(st_setSRID(? ::geometry, 4326), the_geom)";
         jdbcTemplate.query(sql, new RowMapper<Integer>() {
             @Override
             public Integer mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/src/main/java/geo/hs/service/DsmService.java
+++ b/src/main/java/geo/hs/service/DsmService.java
@@ -23,7 +23,7 @@ public class DsmService {
 	public List<Dsm> getDsm(String cityId){
 		// 만약 cityId가 길게 넘어온다면 parsing Code 짜기
 		List<Dsm> dsm = getDsmRepository.getDsm(cityId);
-		Collections.sort(dsm);
+		//Collections.sort(dsm);
 		return dsm;
 	}
 	


### PR DESCRIPTION
이제 DSM 테이블의 x,y,z값은 문자가 아닌 실수 타입을 가지기 때문에 기존 string으로 변환하는 코드는 분리하면 될 거 같습니다.

DSM에 정확한 시군구 코드를 넣을 수 있게 돼서 getAllDSM 메소드는 제거했습니다.

그리고 시도 단위로 도로 hillshade를 보여주지 말고 시군구 단위로 도로 hillshade를 보여주는건 어떻게 생각하시나요?
현재 서울쪽 dsm 파일 하나로 계산한 결과 200초 정도 나오지만 시군구 단위로 계산하면 10초 내에 해결할 수 있을 거 같습니다.
(행정코드 11140으로 도로 hillshade 계산 결과 5000개의 DSM을 가져오고, hillshade 계산을 3초에 끝나는 것을 확인했습니다.)