### PR TITLE
fix: mapXY에 저장하는 키 이름 변경

### DIFF
--- a/src/main/java/geo/hs/service/DsmService.java
+++ b/src/main/java/geo/hs/service/DsmService.java
@@ -55,7 +55,7 @@ public class DsmService {
 				y.add(Double.parseDouble(dsmY));
 			}
 
-			mapXY.put(dsmX + dsmY, dsm);
+			mapXY.put(dsmY + dsmX, dsm);
 		}
 
 		// y, x 좌표 순서대로 정렬 (y축은 내림차순으로, x축은 오름차순으로)
@@ -79,7 +79,7 @@ public class DsmService {
 		}
 		
 		return arr;
-		
+
 	}
 	
 	public List<Dsm> getAllDsm(){


### PR DESCRIPTION
dsmY + dsmX로 key 값을 저장하는 것이 맞는데, 제가 리팩토링하는 과정에서 dsmX + dsmY로 key값을 변경해버려서 수정했습니다
수정해서 실행시 코드 잘 돌아갑니다