### PR TITLE
Refact: docker compose 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,24 @@
 version: "3.9"
-volumes:
-  postgis-data:
-  geoserver-data:
 
 services:
   db:
     image: postgis/postgis
-    volumes:
-      - postgis-data:/var/lib/postgresql
+    hostname: postgres
     environment:
       - POSTGRES_DB=geor
       - POSTGRES_USER=geor
       - POSTGRES_PASSWORD=geor
-      - ALLOW_IP_RANGE=0.0.0.0/0
       - POSTGRES_MULTIPLE_EXTENSIONS=postgis
     ports:
       - "5431:5432"
-    networks:
-      geor_net:
-        ipv4_address: 172.18.0.2
-      
 
   geoserver:
     image: kartoza/geoserver
-    volumes:
-        - geoserver-data:/opt/geoserver/data_dir
     environment:
       - GEOSERVER_ADMIN_USER=admin
       - GEOSERVER_ADMIN_PASSWORD=geoserver
     ports:
       - "8600:8080"
-    networks:
-      geor_net:
-        ipv4_address: 172.18.0.3
 
   pgadmin4:
     image: dpage/pgadmin4
@@ -41,13 +27,3 @@ services:
       - PGADMIN_DEFAULT_PASSWORD=geor
     ports:
       - "5430:80"
-    networks:
-      geor_net:
-        ipv4_address: 172.18.0.4
-
-networks:
-  geor_net:
-    ipam:
-      driver: default
-      config:
-        - subnet: "172.18.0.0/16"


### PR DESCRIPTION
ip를 고정할당 하지 않고 컨테이너끼리 연결이 가능하게 했습니다.
또한, 컨테이너와 호스트 간 공유할 데이터가 없기 때문에 volume도 삭제했습니다.

컴포즈를 재구성하게 되면 pgadmin과 geoserver에서 세팅한걸 바꿔야 하는데 이 부분은 노션에 반영해놨습니다!