### PR TITLE
검색 시 Crawler에서 nullPointException이 발생하던 문제를 해결

### DIFF
--- a/src/main/java/geo/hs/crawling/Crawler.java
+++ b/src/main/java/geo/hs/crawling/Crawler.java
@@ -56,7 +56,7 @@ public class Crawler {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
-			driver.quit();
+			if (driver != null) driver.quit();
 		}
 	}
 

--- a/src/main/java/geo/hs/crawling/Crawler.java
+++ b/src/main/java/geo/hs/crawling/Crawler.java
@@ -17,19 +17,22 @@ import java.util.concurrent.TimeUnit;
 @Getter
 @Setter
 public class Crawler {
-	
+
 	private String url = "https://astro.kasi.re.kr/life/pageView/10";
 	private String address = "crawl";
 	private Double latitude, longitude;
 	private double x_dir, y_dir;
 	private ArrayList<SunInfo> si = new ArrayList<>();
-	
-	public void run(double lat, double lng, String date){
+
+	public void run(double lat, double lng, String date) {
 		WebDriver driver = null;
 		WebElement element = null;
 
-		latitude = lat; longitude = lng; x_dir = lat; y_dir = lng;
-		
+		latitude = lat;
+		longitude = lng;
+		x_dir = lat;
+		y_dir = lng;
+
 		try {
 			// 크롬 버전에 맞게 chromedriver 설치
 			WebDriverManager.chromedriver().setup();
@@ -38,39 +41,44 @@ public class Crawler {
 			ChromeOptions chromeOptions = new ChromeOptions();
 			chromeOptions.addArguments("--headless");
 			chromeOptions.addArguments("--no-sandbox");
+
+			// TODO ChromeDriver를 설정할 때 오류가 발생하고 있습니다.
 			driver = new ChromeDriver(chromeOptions);
-			
+
 			// URL로 접속 (이때 address는 중요하지 않다. 위,경도 좌표만 제대로 입력하면 고도각이 출력된다)
-			driver.get(url+"?useElevation=1&lat="+ lat +"&lng="+ lng +"&elevation=0&output_range=1&date="+date+"&hour=&minute=&second=&address="+address);
+			driver.get(url + "?useElevation=1&lat=" + lat + "&lng=" + lng + "&elevation=0&output_range=1&date=" + date
+					+ "&hour=&minute=&second=&address=" + address);
 
 			// 대기 설정
 			driver.manage().timeouts().implicitlyWait(2, TimeUnit.SECONDS);
-			
-			List<WebElement> tr = ((ChromeDriver) driver).findElementsByXPath("//*[@id=\"sun-height-table\"]/table/tbody/tr");
-			
+
+			List<WebElement> tr = ((ChromeDriver) driver)
+					.findElementsByXPath("//*[@id=\"sun-height-table\"]/table/tbody/tr");
+
 			// 출력
-//			for(int i = 0; i<tr.size(); i++) System.out.println(tr.get(i).getText());
-			
+			// for(int i = 0; i<tr.size(); i++) System.out.println(tr.get(i).getText());
+
 			crawlerParsing(tr);
 
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
-			if (driver != null) driver.quit();
+			if (driver != null)
+				driver.quit();
 		}
 	}
 
 	/**
-	 	2021-11-24
-		작성자 : 김태현
-		내용 : 태양 고도각 관련 정보 크롤링 결과 파싱
-		목적 : 크롤러 정보 get 함수로 깔끔하게 보내기 위함
-	*/
-	
-	private void crawlerParsing(List<WebElement> arr){
-		for(int i = 0; i < arr.size(); i++){
+	 * 2021-11-24
+	 * 작성자 : 김태현
+	 * 내용 : 태양 고도각 관련 정보 크롤링 결과 파싱
+	 * 목적 : 크롤러 정보 get 함수로 깔끔하게 보내기 위함
+	 */
+
+	private void crawlerParsing(List<WebElement> arr) {
+		for (int i = 0; i < arr.size(); i++) {
 			List<String> strings = Arrays.asList(arr.get(i).getText().split(" "));
-			SunInfo s = new SunInfo(0, 0, 0D, 0D, 0,0D,0D,0D,0D);
+			SunInfo s = new SunInfo(0, 0, 0D, 0D, 0, 0D, 0D, 0D, 0D);
 
 			s.setTime(i);
 			s.setLatitude(latitude);
@@ -78,7 +86,7 @@ public class Crawler {
 			s.setX(x_dir);
 			s.setY(y_dir);
 
-			for(int k = 1; k <= 12; k += 3) {
+			for (int k = 1; k <= 12; k += 3) {
 				double hour = Double.parseDouble(strings.get(k));
 				double minute = Double.parseDouble(strings.get(k + 1));
 				double second = Double.parseDouble(strings.get(k + 2));
@@ -89,14 +97,18 @@ public class Crawler {
 				// 적경을 각도로 변환. 각도 = 시간 + (분/60) + (초/3600))
 				double degree = hour + minute / 60 + second / 3600;
 
-				if (k == 1) s.setAzimuth(degree);
-				else if (k == 4) s.setAltitude(degree);
-				else if (k == 7) s.setAscension(t);
-				else s.setDeclination(degree);
+				if (k == 1)
+					s.setAzimuth(degree);
+				else if (k == 4)
+					s.setAltitude(degree);
+				else if (k == 7)
+					s.setAscension(t);
+				else
+					s.setDeclination(degree);
 			}
 
 			si.add(s);
 		}
 	}
-	
+
 }

--- a/src/main/java/geo/hs/crawling/crawler.log
+++ b/src/main/java/geo/hs/crawling/crawler.log
@@ -1,0 +1,165 @@
+Starting ChromeDriver 106.0.5249.61 (511755355844955cd3e264779baf0dd38212a4d0-refs/branch-heads/5249@{#569}) on port 10463
+Only local connections are allowed.
+Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
+ChromeDriver was started successfully.
+org.openqa.selenium.WebDriverException: unknown error: cannot find Chrome binary
+Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
+System info: host: 'N', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '5.10.16.3-microsoft-standard-WSL2', java.version: '11.0.16'
+Driver info: driver.version: ChromeDriver
+remote stacktrace: #0 0x5555ec8eb2c3 <unknown>
+#1 0x5555ec6f483a <unknown>
+#2 0x5555ec7177f4 <unknown>
+#3 0x5555ec715546 <unknown>
+#4 0x5555ec753de6 <unknown>
+#5 0x5555ec75374f <unknown>
+#6 0x5555ec74bd63 <unknown>
+#7 0x5555ec7207e3 <unknown>
+#8 0x5555ec721a21 <unknown>
+#9 0x5555ec93918e <unknown>
+#10 0x5555ec93c622 <unknown>
+#11 0x5555ec91faae <unknown>
+#12 0x5555ec93d2a3 <unknown>
+#13 0x5555ec913ecf <unknown>
+#14 0x5555ec95d588 <unknown>
+#15 0x5555ec95d706 <unknown>
+#16 0x5555ec9778b2 <unknown>
+#17 0x7fc6f0b33609 <unknown>
+
+        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
+        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
+        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
+        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
+        at org.openqa.selenium.remote.W3CHandshakeResponse.lambda$errorHandler$0(W3CHandshakeResponse.java:62)
+        at org.openqa.selenium.remote.HandshakeResponse.lambda$getResponseFunction$0(HandshakeResponse.java:30)
+        at org.openqa.selenium.remote.ProtocolHandshake.lambda$createSession$0(ProtocolHandshake.java:126)
+        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
+        at java.base/java.util.Spliterators$ArraySpliterator.tryAdvance(Spliterators.java:958)
+        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:127)
+        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:502)
+        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:488)
+        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
+        at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
+        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
+        at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:543)
+        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:128)
+        at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:74)
+        at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:136)
+        at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
+        at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
+        at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:213)
+        at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:131)
+        at org.openqa.selenium.chrome.ChromeDriver.<init>(ChromeDriver.java:181)
+        at org.openqa.selenium.chrome.ChromeDriver.<init>(ChromeDriver.java:168)
+        at org.openqa.selenium.chrome.ChromeDriver.<init>(ChromeDriver.java:157)
+        at geo.hs.crawling.Crawler.run(Crawler.java:41)
+        at geo.hs.controller.HillShadeController.updateHillShade(HillShadeController.java:49)
+        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
+        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
+        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
+        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
+        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
+        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
+        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
+        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)
+        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
+        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
+        at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909)
+        at javax.servlet.http.HttpServlet.service(HttpServlet.java:681)
+        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
+        at javax.servlet.http.HttpServlet.service(HttpServlet.java:764)
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
+        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
+        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
+        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
+        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
+        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197)
+        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97)
+        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541)
+        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135)
+        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92)
+        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78)
+        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:360)
+        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
+        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)
+        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890)
+        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743)
+        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
+        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
+        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
+        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
+        at java.base/java.lang.Thread.run(Thread.java:829)
+2022-10-19 04:40:40.422 ERROR 29954 --- [nio-8080-exec-2] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0] with root cause
+
+java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
+        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[na:na]
+        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[na:na]
+        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248) ~[na:na]
+        at java.base/java.util.Objects.checkIndex(Objects.java:372) ~[na:na]
+        at java.base/java.util.ArrayList.get(ArrayList.java:459) ~[na:na]
+        at geo.hs.controller.HillShadeController.updateHillShade(HillShadeController.java:55) ~[main/:na]
+        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
+        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
+        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
+        at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
+        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:909) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at javax.servlet.http.HttpServlet.service(HttpServlet.java:681) ~[tomcat-embed-core-9.0.62.jar:4.0.FR]
+        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.19.jar:5.3.19]
+        at javax.servlet.http.HttpServlet.service(HttpServlet.java:764) ~[tomcat-embed-core-9.0.62.jar:4.0.FR]
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat-embed-websocket-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.19.jar:5.3.19]
+        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:197) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:97) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:135) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:78) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:360) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:890) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.62.jar:9.0.62]
+        at java.base/java.lang.Thread.run(Thread.java:829) ~[na:na]
+


### PR DESCRIPTION
임의의 지역에 대해 분석을 시작할 때 /hillshade에서 NullPointerException이 발생했는데, 그 원인이 driver가 설정되기 전에 Exception이 발생해 finally로 넘어간 경우 Null의 quit 메소드를 호출한 것이었습니다.

추가적으로, ChromeDriver 인스턴스를 호출할 때 Exception이 발생합니다. 에러 메세지를 log 파일로 저장하였습니다.